### PR TITLE
fix: mount TMP directories for Singularity

### DIFF
--- a/zarp/snakemake/run.py
+++ b/zarp/snakemake/run.py
@@ -1,5 +1,6 @@
 """Module for executing Snakemake workflows."""
 
+import os
 import logging
 from pathlib import Path
 import subprocess
@@ -49,10 +50,13 @@ class SnakemakeExecutor:
             snakefile: Path to Snakemake descriptor file.
         """
         bind_paths: List[str] = [
-            str(self.exec_dir),
-            str(self.run_config.working_directory),
-            str(self.run_config.zarp_directory),
+            self.exec_dir,
+            self.run_config.working_directory,
+            self.run_config.zarp_directory,
+            os.environ.get("TMP"),
+            os.environ.get("TMPDIR"),
         ]
+        bind_paths = [str(item) for item in bind_paths if item is not None]
         if self.bind_paths is not None:
             bind_paths.extend([str(path) for path in self.bind_paths])
         bind_paths_arg: str = ",".join(bind_paths)

--- a/zarp/snakemake/run.py
+++ b/zarp/snakemake/run.py
@@ -4,7 +4,7 @@ import os
 import logging
 from pathlib import Path
 import subprocess
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from zarp.config.enums import SnakemakeRunState
 from zarp.config.models import ConfigRun
@@ -49,17 +49,19 @@ class SnakemakeExecutor:
         Args:
             snakefile: Path to Snakemake descriptor file.
         """
-        bind_paths: List[str] = [
+        bind_paths: List[Optional[Union[Path, str]]] = [
             self.exec_dir,
             self.run_config.working_directory,
             self.run_config.zarp_directory,
             os.environ.get("TMP"),
             os.environ.get("TMPDIR"),
         ]
-        bind_paths = [str(item) for item in bind_paths if item is not None]
+        bind_paths_str: List[str] = [
+            str(item) for item in bind_paths if item is not None
+        ]
         if self.bind_paths is not None:
-            bind_paths.extend([str(path) for path in self.bind_paths])
-        bind_paths_arg: str = ",".join(bind_paths)
+            bind_paths_str.extend([str(path) for path in self.bind_paths])
+        bind_paths_arg: str = ",".join(bind_paths_str)
         cmd_ls = ["snakemake"]
         cmd_ls.extend(["--snakefile", str(snakefile)])
         cmd_ls.extend(["--cores", str(self.run_config.cores)])

--- a/zarp/snakemake/run.py
+++ b/zarp/snakemake/run.py
@@ -1,7 +1,7 @@
 """Module for executing Snakemake workflows."""
 
-import os
 import logging
+import os
 from pathlib import Path
 import subprocess
 from typing import List, Optional, Union


### PR DESCRIPTION
Error was raised in htsinfer, as tmp directory could not be created. 

Mounting the os tmp dir in the corresponding singularity container fixed this

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

Please carefully read these items and tick them off if the statements are true
_or do not apply_.

- [x] I have performed a self-review of my own code
- [x] My code follows the existing coding style, lints and generates no new
      warnings
- [x] I have added type annotations to all function/method signatures, and I
      have added type annotations for any local variables that are non-trivial,
      potentially ambiguous or might otherwise benefit from explicit typing.
- [x] I have commented my code in hard-to-understand areas
- [x] I have added [Google-style
      docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)
      to all new modules, classes,
      methods/functions or updated previously existing ones
- [x] I have added tests that prove my fix is effective or that my feature
      works
- [x] New and existing unit tests pass locally with my changes and I have not
      reduced the code coverage relative to the previous state
- [x] I have updated any sections of the app's documentation that are affected
      by the proposed changes

If for some reason you are unable to tick off all boxes, please leave a
comment explaining the issue you are facing so that we can work on it
together.