### PR TITLE
fix: propagate HTSinfer inferences

### DIFF
--- a/tests/files/zarp/workflow/Snakefile
+++ b/tests/files/zarp/workflow/Snakefile
@@ -1,4 +1,4 @@
-"""Dummy version of Snakefile for inferring sample metadata with HTSinfer."""
+"""Dummy version of Snakefile for ZARP workflow."""
 
 
 localrules:
@@ -8,14 +8,14 @@ localrules:
 
 rule all:
     input:
-        config["samples_out"],
+        "zarp_dummy_output",
 
 
 rule dummy:
     input:
         config["samples"],
     output:
-        config["samples_out"],
+        "zarp_dummy_output",
     shell:
         'cat {input} > {output}'
 

--- a/tests/plugins/sample_processors/test_htsinfer.py
+++ b/tests/plugins/sample_processors/test_htsinfer.py
@@ -67,16 +67,17 @@ class TestSampleProcessorHTSinfer:
 
         def patched_run(self, cmd) -> None:
             """Patch `run()` method."""
-            run_dir = Path(tmpdir)
+            run_dir = Path(tmpdir) / "runs" / config.run.identifier
             src = Path(__file__).parents[2] / "files" / "sample_table.tsv"
-            dst_in = run_dir / "samples_result.tsv"
-            dst_out = run_dir / "samples_htsinfer.tsv"
+            dst_in = run_dir / "samples_htsinfer.tsv"
+            dst_out = run_dir / "samples_result.tsv"
+            print(dst_out)
             shutil.copyfile(src, dst_in)
             shutil.copyfile(src, dst_out)
 
         monkeypatch.setattr(SnakemakeExecutor, "run", patched_run)
         df_out = hts.process(loc=outdir, workflow=workflow)
-        assert len(df_out.index) == 2
+        assert len(df_out.index) == 5
 
     def test_process_empty(self, tmpdir, caplog):
         """Test `.process()` method with no records."""
@@ -104,16 +105,16 @@ class TestSampleProcessorHTSinfer:
 
         def patched_run(self, cmd) -> None:
             """Patch `run()` method."""
-            run_dir = Path(tmpdir)
+            run_dir = Path(tmpdir) / "runs" / config.run.identifier
             src = Path(__file__).parents[2] / "files" / "sample_table.tsv"
-            dst_in = run_dir / "samples_result.tsv"
-            dst_out = run_dir / "samples_htsinfer.tsv"
+            dst_in = run_dir / "samples_htsinfer.tsv"
+            dst_out = run_dir / "samples_result.tsv"
             shutil.copyfile(src, dst_in)
             shutil.copyfile(src, dst_out)
 
         monkeypatch.setattr(SnakemakeExecutor, "run", patched_run)
         df_out = hts.process(loc=outdir, workflow=workflow)
-        assert len(df_out.index) == 2
+        assert len(df_out.index) == 5
 
     def test__configure_run(self, tmpdir):
         """Test `._configure_run()` method."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,7 +59,7 @@ class TestMain:
         )
         with pytest.raises(SystemExit) as exc:
             main()
-        assert exc.value.code == 1
+        assert exc.value.code == 0
 
     def test_normal_mode_with_runtime_error(self, monkeypatch, tmpdir):
         """Call with runtime error being raised."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,7 +59,7 @@ class TestMain:
         )
         with pytest.raises(SystemExit) as exc:
             main()
-        assert exc.value.code == 0
+        assert exc.value.code == 1
 
     def test_normal_mode_with_runtime_error(self, monkeypatch, tmpdir):
         """Call with runtime error being raised."""

--- a/zarp/plugins/sample_processors/htsinfer.py
+++ b/zarp/plugins/sample_processors/htsinfer.py
@@ -64,7 +64,7 @@ class SampleProcessorHTSinfer(
         LOGGER.debug(f"Command: {cmd}")
         executor.run(cmd=cmd)
         records_new = stp.read(
-            path=content.samples_out,
+            path=Path(content.samples_out),
             mapping=map_zarp_to_model,
         )
         return records_new

--- a/zarp/plugins/sample_processors/htsinfer.py
+++ b/zarp/plugins/sample_processors/htsinfer.py
@@ -7,7 +7,7 @@ from typing import List, Tuple
 import pandas as pd
 
 from zarp.abstract_classes.sample_processor import SampleProcessor
-from zarp.config.mappings import map_model_to_zarp
+from zarp.config.mappings import map_model_to_zarp, map_zarp_to_model
 from zarp.config.models import ConfigFileHTSinfer
 from zarp.samples import sample_table_processor as stp
 from zarp.snakemake.config_file_processor import ConfigFileProcessor
@@ -50,7 +50,7 @@ class SampleProcessorHTSinfer(
             LOGGER.debug("No metadata to infer.")
             return self.records
         LOGGER.info("Inferring missing metadata...")
-        conf_file, _ = self._configure_run(root_dir=loc)
+        conf_file, content = self._configure_run(root_dir=loc)
         bind_paths: List[Path] = list(
             self.records.paths_1.append(self.records.paths_2).dropna().unique()
         )
@@ -63,7 +63,11 @@ class SampleProcessorHTSinfer(
         cmd = executor.compile_command(snakefile=workflow)
         LOGGER.debug(f"Command: {cmd}")
         executor.run(cmd=cmd)
-        return self.records
+        records_new = stp.read(
+            path=content.samples_out,
+            mapping=map_zarp_to_model,
+        )
+        return records_new
 
     def _configure_run(
         self,


### PR DESCRIPTION
The updated sample table generated by the HTSinfer pipeline was never read to update the internal sample processor object.

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

Please carefully read these items and tick them off if the statements are true
_or do not apply_.

- [x] I have performed a self-review of my own code
- [x] My code follows the existing coding style, lints and generates no new
      warnings
- [x] I have added type annotations to all function/method signatures, and I
      have added type annotations for any local variables that are non-trivial,
      potentially ambiguous or might otherwise benefit from explicit typing.
- [x] I have commented my code in hard-to-understand areas
- [x] I have added [Google-style
      docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)
      to all new modules, classes,
      methods/functions or updated previously existing ones
- [x] I have added tests that prove my fix is effective or that my feature
      works
- [x] New and existing unit tests pass locally with my changes and I have not
      reduced the code coverage relative to the previous state
- [x] I have updated any sections of the app's documentation that are affected
      by the proposed changes