### PR TITLE
fix: various pre-release fixes

### DIFF
--- a/data/genome_assemblies.csv
+++ b/data/genome_assemblies.csv
@@ -103,7 +103,7 @@ coffea_canephora;49390;AUK_PRJEB4211_v1
 labrus_bergylta;56723;BallGen_V1
 aquila_chrysaetos;223781;bAquChr1.2
 vombatus_ursinus;29139;bare-nosed_wombat_genome_assembly
-drosophila_melanogaster;7227,dmelanogaster;BDGP6.32
+drosophila_melanogaster;7227,dmelanogaster;BDGP6.46
 biomphalaria_glabrata;6526;BglaB1
 bigelowiella_natans;753081;Bigna1
 bombus_impatiens;132113;BIMP_2.2

--- a/tests/config/test_init.py
+++ b/tests/config/test_init.py
@@ -49,7 +49,6 @@ class TestInitializer:
             contents=test_config,
             path=config_file,
         )
-        print(config_file)
         initializer.set_from_file(config_file=config_file)
         assert exec_mode_before_update == ExecModes.RUN.value
         assert initializer.config.run.execution_mode == ExecModes.DRY_RUN.value

--- a/tests/plugins/sample_processors/test_htsinfer.py
+++ b/tests/plugins/sample_processors/test_htsinfer.py
@@ -114,7 +114,7 @@ class TestSampleProcessorHTSinfer:
 
         monkeypatch.setattr(SnakemakeExecutor, "run", patched_run)
         df_out = hts.process(loc=outdir, workflow=workflow)
-        assert len(df_out.index) == 5
+        assert len(df_out.index) == len(srp.records.index)
 
     def test__configure_run(self, tmpdir):
         """Test `._configure_run()` method."""

--- a/tests/runner/test_zarp_runner.py
+++ b/tests/runner/test_zarp_runner.py
@@ -58,7 +58,8 @@ class TestSampleRunnerZARP:
         srp.append(df)
         srz = SRZ(config=config, records=srp.records)
         assert hasattr(srz, "records")
-        assert len(srz.records.index) == 2
+        assert len(srp.records.index) == 2
+        assert len(srz.records.index) == 1
 
     def test__configure_run(self, tmpdir):
         """Test `._configure_run()` method."""
@@ -152,7 +153,9 @@ class TestSampleRunnerZARP:
 
         monkeypatch.setattr(SnakemakeExecutor, "run", patched_run)
         df_out = srz.process(loc=outdir, workflow=workflow)
-        assert len(df_out.index) == 2
+        assert len(srp.records.index) == 2
+        assert len(srz.records.index) == 1
+        assert len(df_out.index) == 1
 
     def test_process_dry_run(self, tmpdir, monkeypatch):
         """Test `.process()` method with dry run."""
@@ -165,4 +168,6 @@ class TestSampleRunnerZARP:
         srp.append(df)
         srz = SRZ(config=config, records=srp.records)
         df_out = srz.process(loc=outdir, workflow=workflow)
-        assert len(df_out.index) == 2
+        assert len(srp.records.index) == 2
+        assert len(srz.records.index) == 1
+        assert len(df_out.index) == 1

--- a/tests/samples/test_sample_record_processor.py
+++ b/tests/samples/test_sample_record_processor.py
@@ -251,9 +251,7 @@ class TestSampleRecordProcessor:
                 "three": [("path1", "path2", None), None, (None, "path2")],
             }
         )
-        print(df)
         df_new = SRP._expand_tuple_columns(df=df)
-        print(df_new)
         assert len(df_new.columns) == 6
         assert "one" in df_new.columns
         assert "two_1" in df_new.columns

--- a/tests/samples/test_sample_table_processor.py
+++ b/tests/samples/test_sample_table_processor.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import numpy as np
+
 from zarp.samples import sample_table_processor as stp
 
 
@@ -23,7 +25,7 @@ class TestRead:
             index_col=0,
         )
         assert len(df.index) > 0
-        assert df.iloc[0, 0] == ""
+        assert df.iloc[0, 0] is np.nan
         assert "sample" not in df.columns
 
     def test_read_with_mapping(self):

--- a/zarp/config/samples.py
+++ b/zarp/config/samples.py
@@ -285,18 +285,18 @@ class SampleProcessor:
         paths: List
         if SampleProcessor._is_unnamed_single_end(ref=ref):
             deref.type = SampleReferenceTypes.LOCAL_LIB_SINGLE
-            deref.lib_paths = (Path(ref).absolute(), None)
+            deref.lib_paths = (Path(ref).expanduser().resolve(), None)
         elif SampleProcessor._is_named_single_end(ref=ref):
             parts = ref.split("@", maxsplit=1)
             deref.type = SampleReferenceTypes.LOCAL_LIB_SINGLE
             deref.name = parts[0]
-            deref.lib_paths = (Path(parts[1]).absolute(), None)
+            deref.lib_paths = (Path(parts[1]).expanduser().resolve(), None)
         elif SampleProcessor._is_unnamed_paired_end(ref=ref):
             paths = ref.split(",")
             deref.type = SampleReferenceTypes.LOCAL_LIB_PAIRED
             deref.lib_paths = (
-                Path(paths[0]).absolute(),
-                Path(paths[1]).absolute(),
+                Path(paths[0]).expanduser().resolve(),
+                Path(paths[1]).expanduser().resolve(),
             )
         elif SampleProcessor._is_named_paired_end(ref):
             parts = ref.split("@", maxsplit=1)
@@ -304,8 +304,8 @@ class SampleProcessor:
             deref.type = SampleReferenceTypes.LOCAL_LIB_PAIRED
             deref.name = parts[0]
             deref.lib_paths = (
-                Path(paths[0]).absolute(),
-                Path(paths[1]).absolute(),
+                Path(paths[0]).expanduser().resolve(),
+                Path(paths[1]).expanduser().resolve(),
             )
         elif SampleProcessor._is_unnamed_seq_identifier(ref=ref):
             deref.type = SampleReferenceTypes.REMOTE_LIB_SRA
@@ -318,7 +318,7 @@ class SampleProcessor:
         elif SampleProcessor._is_sample_table(ref=ref):
             parts = ref.split(":", maxsplit=1)
             deref.type = SampleReferenceTypes.TABLE
-            deref.table_path = Path(parts[1]).absolute()
+            deref.table_path = Path(parts[1]).expanduser().resolve()
         return deref
 
     @staticmethod
@@ -333,7 +333,7 @@ class SampleProcessor:
         Returns:
             True if sample reference is an unnamed single-end library.
         """
-        return Path(ref).is_file()
+        return Path(ref).expanduser().is_file()
 
     @staticmethod
     def _is_named_single_end(
@@ -351,7 +351,7 @@ class SampleProcessor:
         return (
             len(parts) == 2
             and bool(search(r"^[a-zA-Z0-9\-\_\.]+$", parts[0]))
-            and Path(parts[1]).is_file()
+            and Path(parts[1]).expanduser().is_file()
         )
 
     @staticmethod
@@ -367,7 +367,9 @@ class SampleProcessor:
             True if sample reference is an unnamed paired-end library.
         """
         paths = ref.split(",")
-        return len(paths) == 2 and all(Path(path).is_file() for path in paths)
+        return len(paths) == 2 and all(
+            Path(path).expanduser().is_file() for path in paths
+        )
 
     @staticmethod
     def _is_named_paired_end(
@@ -386,7 +388,10 @@ class SampleProcessor:
             len(parts) == 2
             and bool(search(r"^[a-zA-Z0-9\-\_\.]+$", parts[0]))
             and len(parts[1].split(",")) == 2
-            and all(Path(path).is_file() for path in parts[1].split(","))
+            and all(
+                Path(path).expanduser().is_file()
+                for path in parts[1].split(",")
+            )
         )
 
     @staticmethod
@@ -438,7 +443,7 @@ class SampleProcessor:
         return (
             len(parts) == 2
             and parts[0] == "table"
-            and Path(parts[1]).is_file()
+            and Path(parts[1]).expanduser().is_file()
         )
 
     @staticmethod

--- a/zarp/plugins/sample_fetchers/sra.py
+++ b/zarp/plugins/sample_fetchers/sra.py
@@ -52,9 +52,8 @@ class SampleFetcherSRA(
             libraries.
         """
         if self.records.empty:
-            LOGGER.debug("No remote libraries to fetch from SRA.")
+            LOGGER.debug("No remote libraries to fetch.")
             return self.records
-        LOGGER.info("Fetching remote libraries from SRA...")
         conf_file: Path
         conf_content: ConfigFileSRA
         conf_file, conf_content = self._configure_run(root_dir=loc)

--- a/zarp/plugins/sample_processors/defaults.py
+++ b/zarp/plugins/sample_processors/defaults.py
@@ -33,16 +33,12 @@ class SampleProcessorDefaults(
         if self.records.empty:
             LOGGER.debug("No defaults to set.")
             return self.records
-
-        LOGGER.info("Setting defaults...")
-
         defaults: Dict[str, Any] = self.config.sample.dict()
         default_data: Dict[str, List[Any]] = {}
         sample_index: pd.Index = self.records.index
         for key, val in defaults.items():
             default_data[key] = [val for _ in range(len(sample_index))]
         default_df: pd.DataFrame = pd.DataFrame(default_data)
-
         srp: SRP = SRP()
         srp.append(self.records)
         srp.update(
@@ -50,9 +46,6 @@ class SampleProcessorDefaults(
             anchor=self.config.run.working_directory,
             path_columns=["annotations", "reference_sequences"],
         )
-
-        LOGGER.info("Defaults set.")
-
         return srp.records
 
     def _select_records(self) -> None:

--- a/zarp/plugins/sample_processors/dummy_data.py
+++ b/zarp/plugins/sample_processors/dummy_data.py
@@ -6,7 +6,6 @@ from typing import Dict, List
 import pandas as pd
 
 from zarp.abstract_classes.sample_processor import SampleProcessor
-from zarp.samples.sample_record_processor import SampleRecordProcessor as SRP
 
 LOGGER = logging.getLogger(__name__)
 
@@ -42,14 +41,11 @@ class SampleProcessorDummyData(
     def process(self) -> pd.DataFrame:
         """Set dummy data for missing sample metadata.
 
-        Returns: Dataframe with dummy data set.
+        Returns: Dataframe with dummy data.
         """
         if self.records.empty:
             LOGGER.debug("No dummy data to set.")
             return self.records
-
-        LOGGER.info("Setting dummy data...")
-
         default_data: Dict[str, List[str]] = {}
         sample_index: pd.Index = self.records.index
         for key in self.columns:
@@ -57,18 +53,7 @@ class SampleProcessorDummyData(
                 self.dummy_data for _ in range(len(sample_index))
             ]
         default_df: pd.DataFrame = pd.DataFrame(default_data)
-
-        srp: SRP = SRP()
-        srp.append(self.records)
-        srp.update(
-            df=default_df,
-            anchor=self.config.run.working_directory,
-            path_columns=["annotations", "reference_sequences"],
-        )
-
-        LOGGER.info("Dummy data set.")
-
-        return srp.records
+        return default_df
 
     def _select_records(self) -> None:
         """Select records to process."""

--- a/zarp/plugins/sample_processors/genomepy.py
+++ b/zarp/plugins/sample_processors/genomepy.py
@@ -45,7 +45,6 @@ class SampleProcessorGenomePy(
             LOGGER.debug("No genome resources to fetch.")
             return self.records
 
-        LOGGER.info("Fetching genome resources...")
         self.set_assemblies()
         resource_paths = self.fetch_resources(genomes_dir_root=loc)
         self.set_resource_paths(resource_paths)

--- a/zarp/runner/zarp_runner.py
+++ b/zarp/runner/zarp_runner.py
@@ -47,7 +47,6 @@ class SampleRunnerZARP(
 
         Returns: Dataframe with inferred sample metadata.
         """
-        LOGGER.info("Preparing ZARP run...")
         if self.records.empty:
             LOGGER.info("No samples to run.")
             return self.records
@@ -157,6 +156,7 @@ class SampleRunnerZARP(
         """Select records to process."""
         for _, row in self.records.iterrows():
             _row = row[map_model_to_zarp.keys()]  # type: ignore
+            LOGGER.warning(_row.to_dict())
             if _row.isnull().any():
                 LOGGER.warning(
                     (

--- a/zarp/samples/sample_record_processor.py
+++ b/zarp/samples/sample_record_processor.py
@@ -78,6 +78,8 @@ class SampleRecordProcessor:
             df: Pandas ``DataFrame`` object.
             by: Column to use as index for update. If ``None`` (default),
                 compares database records by position.
+            overwrite: Overwrite existing records. If ``False`` (default),
+                existing records will not be updated.
             **kwargs: Keyword arguments to pass to ``_sanitize_df()``.
 
         Raises:

--- a/zarp/samples/sample_table_processor.py
+++ b/zarp/samples/sample_table_processor.py
@@ -33,7 +33,6 @@ def read(
         path,
         comment="#",
         sep="\t",
-        keep_default_na=False,
         dtype=str,
         index_col=index_col,
         usecols=columns,  # type: ignore

--- a/zarp/zarp.py
+++ b/zarp/zarp.py
@@ -84,15 +84,18 @@ class ZARP:
         srp.view()
 
         # fill defaults
+        LOGGER.info("Setting defaults...")
         processor_defaults = SampleProcessorDefaults(
             config=self.config,
             records=srp.records,
         )
         df = processor_defaults.process()
         srp.update(df=df)
+        LOGGER.info("Defaults set.")
         srp.view()
 
         # fetch remote samples from SRA
+        LOGGER.info("Fetching remote libraries from SRA...")
         fetcher_sra = SampleFetcherSRA(
             config=self.config,
             records=srp.records,
@@ -105,9 +108,11 @@ class ZARP:
             / "sra_download.smk",
         )
         srp.update(df=df, by="identifier")
+        LOGGER.info("Local sample paths set.")
         srp.view()
 
         # infer sample metadata with HTSinfer
+        LOGGER.info("Inferring metadata...")
         processor_htsinfer = SampleProcessorHTSinfer(
             config=self.config,
             records=srp.records,
@@ -120,9 +125,11 @@ class ZARP:
             / "htsinfer.smk",
         )
         srp.update(df=df)
+        LOGGER.info("Missing metadata set.")
         srp.view()
 
         # fetch genome resources with genomepy
+        LOGGER.info("Fetching genome resources...")
         fetcher_genomepy = SampleProcessorGenomePy(
             config=self.config,
             records=srp.records,
@@ -131,15 +138,18 @@ class ZARP:
             loc=self.config.run.working_directory / "genomes",
         )
         srp.update(df=df, overwrite=True)
+        LOGGER.info("Genome resource paths set...")
         srp.view()
 
         # fill with dummy data
+        LOGGER.info("Setting dummy data...")
         processor_dummy_data = SampleProcessorDummyData(
             config=self.config,
             records=srp.records,
         )
         df = processor_dummy_data.process()
         srp.update(df=df)
+        LOGGER.info("Dummy data set...")
         srp.view()
 
         return srp
@@ -150,6 +160,7 @@ class ZARP:
         Args:
             samples: Sample record processor instance.
         """
+        LOGGER.info("Preparing ZARP run...")
         runner_zarp = SampleRunnerZARP(
             config=self.config,
             records=samples.records,
@@ -158,3 +169,4 @@ class ZARP:
             loc=self.config.run.working_directory / "zarp",
             workflow=self.config.run.zarp_directory / "workflow" / "Snakefile",
         )
+        LOGGER.info("ZARP run completed.")


### PR DESCRIPTION
- fix sample metadata propagation flow; several different end-to-end test cases ran successfully 
- explicitly support tilde user home expansion when dereferencing local file paths, including in paired-ended libraries, e.g., in `~/file_1.fq.gz,~/file_2.fq.gz`, `~` would be expanded to the value of `$HOME`
- update _D. melanogaster_ genome from `BDGP6.32` to `BDGP6.46` in `data/genome_assemblies.csv`, as the former was not available to `genomepy`