### PR TITLE
fix: various prerelease fixes

### DIFF
--- a/data/genome_assemblies.csv
+++ b/data/genome_assemblies.csv
@@ -213,7 +213,7 @@ glossina_pallidipes;7398;GpalI1
 glossina_palpalis;67801;GpapI1
 gossypium_raimondii;29730;Graimondii2_0_v6
 gallus_gallus;9031,ggallus;GRCg6a
-homo_sapiens;9606;GRCh38.p13
+homo_sapiens;9606;GRCh38.p14
 mus_musculus;10090,mmusculus;GRCm39
 danio_rerio;7955,drerio;GRCz11
 guillardia_theta;905079;Guith1

--- a/tests/plugins/sample_processors/test_htsinfer.py
+++ b/tests/plugins/sample_processors/test_htsinfer.py
@@ -71,7 +71,6 @@ class TestSampleProcessorHTSinfer:
             src = Path(__file__).parents[2] / "files" / "sample_table.tsv"
             dst_in = run_dir / "samples_htsinfer.tsv"
             dst_out = run_dir / "samples_result.tsv"
-            print(dst_out)
             shutil.copyfile(src, dst_in)
             shutil.copyfile(src, dst_out)
 

--- a/tests/snakemake/test_config_file_processor.py
+++ b/tests/snakemake/test_config_file_processor.py
@@ -51,11 +51,8 @@ class TestConfigFileProcessor:
         )
         cfp.set_content(content=content)
         assert cfp.content == content
-        print(cfp.content.dict())
         cfp.write(Path(tmpdir) / "config.yaml")
         assert (Path(tmpdir) / "config.yaml").is_file()
-        print(Path(tmpdir) / "config.yaml")
-        print(cfp.content.dict())
         with open(Path(tmpdir) / "config.yaml", "r") as _file:
             assert (
                 _file.read()

--- a/tests/snakemake/test_run.py
+++ b/tests/snakemake/test_run.py
@@ -104,17 +104,6 @@ class TestSnakemakeExecutor:
         my_param = f"--use-{dependency_embedding.value.lower()}"
         assert my_param in cmd
 
-    def test_compile_command_dep_embedding_sra_exception(self, tmpdir):
-        """Execute a run with different dependency embedding strategies."""
-        snakefile = create_snakefile(dir=Path(tmpdir), name="sra_download.smk")
-        run_config = default_run_config.copy(deep=True)
-        run_config.dependency_embedding = (
-            DependencyEmbeddingStrategies.SINGULARITY
-        )
-        my_run = SnakemakeExecutor(run_config=run_config, exec_dir=tmpdir)
-        cmd = my_run.compile_command(snakefile=snakefile)
-        assert "--use-singularity" not in cmd
-
     @pytest.mark.parametrize(
         "exec_mode", [ExecModes.RUN, ExecModes.DRY_RUN, ExecModes.PREPARE_RUN]
     )

--- a/tests/snakemake/test_run.py
+++ b/tests/snakemake/test_run.py
@@ -69,6 +69,7 @@ class TestSnakemakeExecutor:
             run_config=run_config,
             config_file=config_file,
             exec_dir=tmpdir,
+            bind_paths=[Path("/path/to/bind")],
         )
         cmd = my_run.compile_command(snakefile=snakefile)
         assert "--configfile" in cmd

--- a/zarp/config/constants.py
+++ b/zarp/config/constants.py
@@ -1,0 +1,3 @@
+"""Constants."""
+
+DUMMY_DATA = "X" * 15

--- a/zarp/plugins/sample_processors/dummy_data.py
+++ b/zarp/plugins/sample_processors/dummy_data.py
@@ -6,6 +6,7 @@ from typing import Dict, List
 import pandas as pd
 
 from zarp.abstract_classes.sample_processor import SampleProcessor
+from zarp.config.constants import DUMMY_DATA
 
 LOGGER = logging.getLogger(__name__)
 
@@ -36,7 +37,6 @@ class SampleProcessorDummyData(
         "adapter_poly_5p_1",
         "adapter_poly_5p_2",
     ]
-    dummy_data = "X" * 15
 
     def process(self) -> pd.DataFrame:
         """Set dummy data for missing sample metadata.
@@ -50,7 +50,7 @@ class SampleProcessorDummyData(
         sample_index: pd.Index = self.records.index
         for key in self.columns:
             default_data[key] = [
-                self.dummy_data for _ in range(len(sample_index))
+                DUMMY_DATA for _ in range(len(sample_index))
             ]
         default_df: pd.DataFrame = pd.DataFrame(default_data)
         return default_df

--- a/zarp/runner/zarp_runner.py
+++ b/zarp/runner/zarp_runner.py
@@ -160,7 +160,7 @@ class SampleRunnerZARP(
                 LOGGER.warning(
                     (
                         f"Sample '{row.loc['name']}' is dropped due to missing"
-                        " metadata."
+                        f" metadata: {_row}"
                     ),
                 )
                 self.records.drop(index=row.name, inplace=True)

--- a/zarp/runner/zarp_runner.py
+++ b/zarp/runner/zarp_runner.py
@@ -156,7 +156,6 @@ class SampleRunnerZARP(
         """Select records to process."""
         for _, row in self.records.iterrows():
             _row = row[map_model_to_zarp.keys()]  # type: ignore
-            LOGGER.warning(_row.to_dict())
             if _row.isnull().any():
                 LOGGER.warning(
                     (

--- a/zarp/snakemake/run.py
+++ b/zarp/snakemake/run.py
@@ -89,17 +89,7 @@ class SnakemakeExecutor:
             else:
                 cmd_ls.append("--use-conda")
         elif self.run_config.dependency_embedding == "SINGULARITY":
-            if snakefile.name == "sra_download.smk":
-                cmd_ls.append("--use-conda")
-                # Singularity is currently not supported for the SRA download
-                # workflow; reason:
-                # https://github.com/snakemake/snakemake/issues/1521
-                LOGGER.warning(
-                    "Singularity not supported for SRA download workflow."
-                    " Using Conda instead."
-                )
-            else:
-                cmd_ls.append("--use-singularity")
+            cmd_ls.append("--use-singularity")
         return cmd_ls
 
     def run(self, cmd) -> None:

--- a/zarp/snakemake/run.py
+++ b/zarp/snakemake/run.py
@@ -74,8 +74,7 @@ class SnakemakeExecutor:
         if self.config_file is not None:
             cmd_ls.extend(["--configfile", str(self.config_file)])
         if self.run_config.profile is not None:
-            if snakefile.name == "Snakefile":
-                cmd_ls.extend(["--profile", str(self.run_config.profile)])
+            cmd_ls.extend(["--profile", str(self.run_config.profile)])
         if self.run_config.execution_mode == "DRY_RUN":
             cmd_ls.append("--dry-run")
         if self.run_config.dependency_embedding == "CONDA":

--- a/zarp/snakemake/run.py
+++ b/zarp/snakemake/run.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import subprocess
 from typing import List, Optional, Union
 
+from zarp.config.constants import DUMMY_DATA
 from zarp.config.enums import SnakemakeRunState
 from zarp.config.models import ConfigRun
 
@@ -56,11 +57,14 @@ class SnakemakeExecutor:
             os.environ.get("TMP"),
             os.environ.get("TMPDIR"),
         ]
-        bind_paths_str: List[str] = [
-            str(item) for item in bind_paths if item is not None
-        ]
+        bind_paths_str: List[str] = list(
+            set(str(item) for item in bind_paths if item is not None)
+        )
         if self.bind_paths is not None:
             bind_paths_str.extend([str(path) for path in self.bind_paths])
+        bind_paths_str = [
+            item for item in bind_paths_str if item != DUMMY_DATA
+        ]
         bind_paths_arg: str = ",".join(bind_paths_str)
         cmd_ls = ["snakemake"]
         cmd_ls.extend(["--snakefile", str(snakefile)])

--- a/zarp/snakemake/run.py
+++ b/zarp/snakemake/run.py
@@ -50,26 +50,9 @@ class SnakemakeExecutor:
         Args:
             snakefile: Path to Snakemake descriptor file.
         """
-        bind_paths: List[Optional[Union[Path, str]]] = [
-            self.exec_dir,
-            self.run_config.working_directory,
-            self.run_config.zarp_directory,
-            os.environ.get("TMP"),
-            os.environ.get("TMPDIR"),
-        ]
-        bind_paths_str: List[str] = list(
-            set(str(item) for item in bind_paths if item is not None)
-        )
-        if self.bind_paths is not None:
-            bind_paths_str.extend([str(path) for path in self.bind_paths])
-        bind_paths_str = [
-            item for item in bind_paths_str if item != DUMMY_DATA
-        ]
-        bind_paths_arg: str = ",".join(bind_paths_str)
         cmd_ls = ["snakemake"]
         cmd_ls.extend(["--snakefile", str(snakefile)])
         cmd_ls.extend(["--cores", str(self.run_config.cores)])
-        cmd_ls.extend(["--singularity-args", f"--bind {bind_paths_arg}"])
         cmd_ls.extend(["--directory", str(self.exec_dir)])
         if self.config_file is not None:
             cmd_ls.extend(["--configfile", str(self.config_file)])
@@ -90,6 +73,23 @@ class SnakemakeExecutor:
                 cmd_ls.append("--use-conda")
         elif self.run_config.dependency_embedding == "SINGULARITY":
             cmd_ls.append("--use-singularity")
+            bind_paths: List[Optional[Union[Path, str]]] = [
+                self.exec_dir,
+                self.run_config.working_directory,
+                self.run_config.zarp_directory,
+                os.environ.get("TMP"),
+                os.environ.get("TMPDIR"),
+            ]
+            bind_paths_str: List[str] = list(
+                set(str(item) for item in bind_paths if item is not None)
+            )
+            if self.bind_paths is not None:
+                bind_paths_str.extend([str(path) for path in self.bind_paths])
+            bind_paths_str = [
+                item for item in bind_paths_str if item != DUMMY_DATA
+            ]
+            bind_paths_arg: str = ",".join(bind_paths_str)
+            cmd_ls.extend(["--singularity-args", f"--bind {bind_paths_arg}"])
         return cmd_ls
 
     def run(self, cmd) -> None:

--- a/zarp/zarp.py
+++ b/zarp/zarp.py
@@ -161,6 +161,7 @@ class ZARP:
             samples: Sample record processor instance.
         """
         LOGGER.info("Preparing ZARP run...")
+        samples.view(level=logging.INFO)
         runner_zarp = SampleRunnerZARP(
             config=self.config,
             records=samples.records,


### PR DESCRIPTION
- chore: remove leftover debug print messages
- fix: sanitize Singularity bind paths (previously led to errors for non-absolute paths resulting from dummy data and warnings about repetitions)
- feat: attach profile to all workflows (but profiles should not contain Conda- or Singularity-specific parameters, as these are managed by ZARP-cli)
- feat: Singularity support for SRA workflow (possible since https://github.com/zavolanlab/zarp/commit/6db184ce541275df9f8e27b57c673eb551447dc8)
- fix: pass bind paths only for Singularity (previously bind paths were also passed when using Conda environments)
- chore: bump hsapiens genome assembly (from `GRCh38.p13` to `GRCh38.p14`)
- feat: log samples before starting ZARP (previously it was not possible to know the last state of the sample metadata before ZARP was started unless `--verbosity` was set to `DEBUG`)
- feat: log context for dropping samples (previously it was more difficult to see why a given sample was dropped)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the existing coding style, lints and generates no new
      warnings
- [x] I have added type annotations to all function/method signatures, and I
      have added type annotations for any local variables that are non-trivial,
      potentially ambiguous or might otherwise benefit from explicit typing.
- [x] I have commented my code in hard-to-understand areas
- [x] I have added [Google-style
      docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)
      to all new modules, classes,
      methods/functions or updated previously existing ones
- [x] I have added tests that prove my fix is effective or that my feature
      works
- [x] New and existing unit tests pass locally with my changes and I have not
      reduced the code coverage relative to the previous state
- [x] I have updated any sections of the app's documentation that are affected
      by the proposed changes