### PR TITLE
feat: Conda support for HTSinfer workflow

### DIFF
--- a/zarp/snakemake/run.py
+++ b/zarp/snakemake/run.py
@@ -65,35 +65,7 @@ class SnakemakeExecutor:
         bind_paths_str: List[str]
         bind_paths_arg: str
         if self.run_config.dependency_embedding == "CONDA":
-            # Conda is currently not supported for the HTSinfer workflow
-            if snakefile.name == "htsinfer.smk":
-                cmd_ls.append("--use-singularity")
-                bind_paths = [
-                    self.exec_dir,
-                    self.run_config.working_directory,
-                    self.run_config.zarp_directory,
-                    os.environ.get("TMP"),
-                    os.environ.get("TMPDIR"),
-                ]
-                bind_paths_str = list(
-                    set(str(item) for item in bind_paths if item is not None)
-                )
-                if self.bind_paths is not None:
-                    bind_paths_str.extend(
-                        [str(path) for path in self.bind_paths]
-                    )
-                bind_paths_str = [
-                    item for item in bind_paths_str if item != DUMMY_DATA
-                ]
-                bind_paths_arg = ",".join(bind_paths_str)
-                cmd_ls.extend(
-                    ["--singularity-args", f"--bind {bind_paths_arg}"])
-                LOGGER.warning(
-                    "Conda not supported for HTSinfer workflow."
-                    " Using Singularity instead."
-                )
-            else:
-                cmd_ls.append("--use-conda")
+            cmd_ls.append("--use-conda")
         elif self.run_config.dependency_embedding == "SINGULARITY":
             cmd_ls.append("--use-singularity")
             bind_paths = [


### PR DESCRIPTION
- Remove restriction to start HTSinfer workflow in Conda mode now that support for Conda execution was added to the workflow in the ZARP repository (https://github.com/zavolanlab/zarp/commit/1dd98df013d6e8e0a86aadf0d99f6aee66dbdda7)

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Checklist

Please carefully read these items and tick them off if the statements are true
_or do not apply_.

- [x] I have performed a self-review of my own code
- [x] My code follows the existing coding style, lints and generates no new
      warnings
- [x] I have added type annotations to all function/method signatures, and I
      have added type annotations for any local variables that are non-trivial,
      potentially ambiguous or might otherwise benefit from explicit typing.
- [x] I have commented my code in hard-to-understand areas
- [x] I have added [Google-style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) to all new modules, classes,
      methods/functions or updated previously existing ones
- [x] I have added tests that prove my fix is effective or that my feature
      works
- [x] New and existing unit tests pass locally with my changes and I have not
      reduced the code coverage relative to the previous state
- [x] I have updated any sections of the app's documentation that are affected
      by the proposed changes

If for some reason you are unable to tick off all boxes, please leave a
comment explaining the issue you are facing so that we can work on it
together.
